### PR TITLE
Feature7 rmq

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -4,5 +4,3 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 COPY . /app
-
-CMD [ "python manage.py runserver 0.0.0.0:8000" ]

--- a/admin/consumer.py
+++ b/admin/consumer.py
@@ -11,7 +11,7 @@ def callback(ch, method, properties, body):
     print('Received message in admin')
     print(body)
 
-channel.basic_consume(queue='admin', on_message_callback=callback)
+channel.basic_consume(queue='admin', on_message_callback=callback, auto_ack=True)
 print('Started Consuming on admin....')
 channel.start_consuming()
 channel.close()

--- a/admin/consumer.py
+++ b/admin/consumer.py
@@ -1,0 +1,17 @@
+import pika
+
+params = pika.URLParameters('amqps://kjfgcgzo:05xbwRBccXE7KL2FskMW-ljJ5W3V9XAy@orangutan.rmq.cloudamqp.com/kjfgcgzo')
+connection = pika.BlockingConnection(params)
+channel = connection.channel()
+
+#declare quueue
+channel.queue_declare(queue='admin')
+
+def callback(ch, method, properties, body):
+    print('Received message in admin')
+    print(body)
+
+channel.basic_consume(queue='admin', on_message_callback=callback)
+print('Started Consuming....')
+channel.start_consuming()
+channel.close()

--- a/admin/docker-compose.yml
+++ b/admin/docker-compose.yml
@@ -12,7 +12,15 @@ services:
       - .:/app
     depends_on:
       - db
-      
+  
+  queue:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: 'python consumer.py'
+    depends_on:
+    - db
+
   db:
     image: mysql:5.7.22
     restart: always

--- a/admin/main/Dockerfile
+++ b/admin/main/Dockerfile
@@ -4,5 +4,3 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r requirements.txt
 COPY . /app
-
-CMD python main.py

--- a/admin/main/consumer.py
+++ b/admin/main/consumer.py
@@ -5,13 +5,13 @@ connection = pika.BlockingConnection(params)
 channel = connection.channel()
 
 #declare quueue
-channel.queue_declare(queue='admin')
+channel.queue_declare(queue='main')
 
 def callback(ch, method, properties, body):
-    print('Received message in admin')
+    print('Received message in main')
     print(body)
 
-channel.basic_consume(queue='admin', on_message_callback=callback)
-print('Started Consuming on admin....')
+channel.basic_consume(queue='main', on_message_callback=callback)
+print('Started Consuming on main....')
 channel.start_consuming()
 channel.close()

--- a/admin/main/consumer.py
+++ b/admin/main/consumer.py
@@ -11,7 +11,7 @@ def callback(ch, method, properties, body):
     print('Received message in main')
     print(body)
 
-channel.basic_consume(queue='main', on_message_callback=callback)
+channel.basic_consume(queue='main', on_message_callback=callback, auto_ack=True)
 print('Started Consuming on main....')
 channel.start_consuming()
 channel.close()

--- a/admin/main/docker-compose.yml
+++ b/admin/main/docker-compose.yml
@@ -5,13 +5,22 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: 'python main.py'
     ports:
       - 5000:5000
     volumes:
       - .:/app
     depends_on:
       - db
-      
+  
+  queue:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: 'python consumer.py'
+    depends_on:
+    - db
+           
   db:
     image: mysql:5.7.22
     restart: always

--- a/admin/products/producer.py
+++ b/admin/products/producer.py
@@ -6,4 +6,4 @@ channel = connection.channel()
 
 #publish now
 def publish():
-    channel.basic_publish(exchange='', routing_key='admin', body='Hello from publish in Products')
+    channel.basic_publish(exchange='', routing_key='main', body='Hello from publish in Products')

--- a/admin/products/producer.py
+++ b/admin/products/producer.py
@@ -1,0 +1,9 @@
+import pika
+
+params = pika.URLParameters('amqps://kjfgcgzo:05xbwRBccXE7KL2FskMW-ljJ5W3V9XAy@orangutan.rmq.cloudamqp.com/kjfgcgzo')
+connection = pika.BlockingConnection(params)
+channel = connection.channel()
+
+#publish now
+def publish():
+    channel.basic_publish(exchange='', routing_key='admin', body='Hello from publish in Products')

--- a/admin/products/views.py
+++ b/admin/products/views.py
@@ -4,12 +4,14 @@ from rest_framework.views import APIView
 
 from .models import Product, User
 from .serializers import ProductSerializer
+from .producer import publish
 import random
 
 class ProductViewSet(viewsets.ViewSet):
     def list(self, request): #/api/products route
         products = Product.objects.all()
         serializer = ProductSerializer(products, many=True)
+        publish()
         return Response(serializer.data)
 
     def create(self, request): #/api/products route

--- a/feature7-rmq.yml
+++ b/feature7-rmq.yml
@@ -45,3 +45,17 @@ PART II:
     Received message in main
     b'Hello from publish in Products'
   """
+
+PART III:
+  Update dockerfile and compose to build queue containers with all needed consumer commands
+  >docker-compose up -d db [shows db logs on console]
+
+  """"
+    queue_1    | Started Consuming on main....
+    queue_1    | Received message in main
+    queue_1    | b'Hello from publish in Products'
+    queue_1    | Received message in main
+    queue_1    | b'Hello from publish in Products'
+  """
+
+  send test events: feature7 "GET products" [see consuming eents on flask app only]

--- a/feature7-rmq.yml
+++ b/feature7-rmq.yml
@@ -1,3 +1,25 @@
 feature7:
   back to django app to create PRODUCER in Products
   use cloud amqp [RMQaaS] to create base cluster 
+  Create consumer in root folder [admin app]
+
+  test:
+    >docker-compose exec backend sh [admin]
+    >python consumer.py
+    
+    send test events: feature7 "GET products"
+    usually see this ERROR: pika.exceptions.ChannelWrongStateError: Channel is closed. - restart both docker
+    
+    """
+      (env) shajith_ravi:admin/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                         [0:01:16]
+      # python consumer.py
+      Started Consuming....
+      Received message in admin
+      b'Hello from publish in Products'
+      Received message in admin
+      b'Hello from publish in Products'
+      Received message in admin
+      b'Hello from publish in Products'
+      Received message in admin
+      b'Hello from publish in Products'
+    """

--- a/feature7-rmq.yml
+++ b/feature7-rmq.yml
@@ -1,0 +1,3 @@
+feature7:
+  back to django app to create PRODUCER in Products
+  use cloud amqp [RMQaaS] to create base cluster 

--- a/feature7-rmq.yml
+++ b/feature7-rmq.yml
@@ -59,3 +59,16 @@ PART III:
   """
 
   send test events: feature7 "GET products" [see consuming eents on flask app only]
+
+
+  PART IV:
+    Add auto_ack=True so we dont se messages just being published and not auto_consumed.
+    You will see docker come up with default print: "Started consuming" - but no backlogged messages.
+
+    """"
+    queue_1    | Started Consuming on main....
+    """" 
+    queue_1    | Started Consuming on admin....
+    """"
+
+    on rmq portal: ready and total will be 0

--- a/feature7-rmq.yml
+++ b/feature7-rmq.yml
@@ -23,3 +23,25 @@ feature7:
       Received message in admin
       b'Hello from publish in Products'
     """
+
+PART II:
+  Add consumer for main app.
+
+  exec to main container
+  (env) shajith_ravi:main/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                          [0:07:56]
+  # python consumer.py
+  Started Consuming on main....
+
+
+  Update PRODUCER to pusblish to main queue.
+  send test events: feature7 "GET products"
+
+  """
+    (env) shajith_ravi:main/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                          [0:07:56]
+    # python consumer.py
+    Started Consuming on main....
+    Received message in main
+    b'Hello from publish in Products'
+    Received message in main
+    b'Hello from publish in Products'
+  """


### PR DESCRIPTION
feature7:
  back to django app to create PRODUCER in Products
  use cloud amqp [RMQaaS] to create base cluster 
  Create consumer in root folder [admin app]

  test:
    >docker-compose exec backend sh [admin]
    >python consumer.py
    
    send test events: feature7 "GET products"
    usually see this ERROR: pika.exceptions.ChannelWrongStateError: Channel is closed. - restart both docker
    
    """
      (env) shajith_ravi:admin/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                         [0:01:16]
      # python consumer.py
      Started Consuming....
      Received message in admin
      b'Hello from publish in Products'
      Received message in admin
      b'Hello from publish in Products'
      Received message in admin
      b'Hello from publish in Products'
      Received message in admin
      b'Hello from publish in Products'
    """

PART II:
  Add consumer for main app.

  exec to main container
  (env) shajith_ravi:main/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                          [0:07:56]
  # python consumer.py
  Started Consuming on main....


  Update PRODUCER to pusblish to main queue.
  send test events: feature7 "GET products"

  """
    (env) shajith_ravi:main/ (feature7-rmq✗) $ docker-compose exec backend sh                                                                                          [0:07:56]
    # python consumer.py
    Started Consuming on main....
    Received message in main
    b'Hello from publish in Products'
    Received message in main
    b'Hello from publish in Products'
  """

PART III:
  Update dockerfile and compose to build queue containers with all needed consumer commands
  >docker-compose up -d db [shows db logs on console]

  """"
    queue_1    | Started Consuming on main....
    queue_1    | Received message in main
    queue_1    | b'Hello from publish in Products'
    queue_1    | Received message in main
    queue_1    | b'Hello from publish in Products'
  """

  send test events: feature7 "GET products" [see consuming eents on flask app only]


  PART IV:
    Add auto_ack=True so we dont se messages just being published and not auto_consumed.
    You will see docker come up with default print: "Started consuming" - but no backlogged messages.

    """"
    queue_1    | Started Consuming on main....
    """" 
    queue_1    | Started Consuming on admin....
    """"

    on rmq portal: ready and total will be 0